### PR TITLE
Manage properly modules with multiple loaders/stages and fix plugin for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { NormalModuleReplacementPlugin } = require('webpack');
-const { resolve } = require('path');
+const { sep } = require('path');
 const escapeStringRegexp = require('escape-string-regexp');
 
 function createMapKey(name, version, file) {
@@ -7,7 +7,7 @@ function createMapKey(name, version, file) {
 }
 
 function createMapKeyFromResource(resource) {
-  const escapedString = escapeStringRegexp(`${resource.resourceResolveData.descriptionFileData.name}/`);
+  const escapedString = escapeStringRegexp(`${resource.resourceResolveData.descriptionFileData.name}${sep}`);
 
   try {
     const file = new RegExp(`${escapedString}.*`).exec(resource.request)[0];

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function createMapKeyFromResource(resource) {
   const escapedString = escapeStringRegexp(`${resource.resourceResolveData.descriptionFileData.name}${sep}`);
 
   try {
-    const file = new RegExp(`${escapedString}.*`).exec(resource.request)[0];
+    const file = new RegExp(`${escapedString}.*`).exec(resource.resource)[0];
 
     return createMapKey(
       resource.resourceResolveData.descriptionFileData.name,
@@ -30,7 +30,7 @@ function isResourceRegistered(map, resource) {
 
 function createDedupe() {
   const map = {};
-  
+
   return new NormalModuleReplacementPlugin(/.*/, function(resource) {
     if (resource.resourceResolveData == null) {
       return;
@@ -38,13 +38,17 @@ function createDedupe() {
 
     try {
       if (isResourceRegistered(map, resource)) {
-        resource.request = map[createMapKeyFromResource(resource)];
-  
+        const registeredResource = map[createMapKeyFromResource(resource)];
+        if (registeredResource === resource.resource) {
+          return;
+        }
+
+        resource.request = resource.request.replace(resource.resource, registeredResource);
         return;
       }
 
-      map[createMapKeyFromResource(resource)] = resource.request;
-      
+      map[createMapKeyFromResource(resource)] = resource.resource;
+
     } catch(err) {
       return;
     }


### PR DESCRIPTION
Hi,

This pull request fixes two issues. 

* **Manage properly modules that are processed by multiple loaders, on multiple stages** - the plugin doesn't work when a module is beeing processed by multiple loaders on mutliple stages (e.g. with a Vue.js app, using vue-compiler-loader and babel-loader). So, instead of replacing the whole request (that contains loader(s) and its parameters), only the path of the module is replaced. 
* **Handle properly Windows environnment** - use environment based separator (instead of "/") in regexp to extract the module name.

I did tests on my side, but can you confirm that all is working properly for you?

Thanks!

